### PR TITLE
bump compileSdkVersion 31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 15


### PR DESCRIPTION
to match same `compileSdkVersion 31` value in `Meshtastic-Android/app/build.gradle`

https://github.com/meshtastic/Meshtastic-Android/commit/37c22786e53cd25253aa16cb0e46dcaf33328129#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9R33